### PR TITLE
added change of scheduler class in set scheduler to fix classes only …

### DIFF
--- a/kernel/sched/core.c
+++ b/kernel/sched/core.c
@@ -7129,8 +7129,10 @@ int default_wake_function(wait_queue_entry_t *curr, unsigned mode, int wake_flag
 EXPORT_SYMBOL(default_wake_function);
 
 static void __setscheduler_prio(struct task_struct *p, int prio)
-{
-	if (dl_prio(prio))
+{	
+	if (ipanema_policy(p->policy))
+		p->sched_class = &ipanema_sched_class;
+	else if (dl_prio(prio))
 		p->sched_class = &dl_sched_class;
 	else if (rt_prio(prio))
 		p->sched_class = &rt_sched_class;


### PR DESCRIPTION
currently the scheduler class is only called when fork is called. So if you start e.g. a python program with ipastart, the set_scheduler syscall will update the scheduler attributes but there will be no changes in the sched_class, leading to wrong function calls.

Test:
Create a python program which just prints something and activate the ipanema_sched_class_log under /sys/kernel/ipanema/ipanema_sched_class_log. You will see, that there is no output in dmesg. The problem here is, that the scheduler class is not changed so the function pointers from the fair scheduler are called and not the ipanema scheduler. 

It worked with bash so far, because bash calls fork for a lot of programs (e.g. sleep is called via a fork)

This pr fixes this issue